### PR TITLE
fix: avoid output of invalid JSON numerical values

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -176,7 +176,7 @@ func TestScrambleJson(t *testing.T) {
 	assertScramble(t, ScrambleJson, "null", "null")
 	assertScramble(t, ScrambleJson, "\"foo\"", "\"ygNhbBZGsu\"")
 	assertScramble(t, ScrambleJson, "\"long long long text\"", "\"zXzRxNYjj3\"")
-	assertScramble(t, ScrambleJson, "1234", "0036")
+	assertScramble(t, ScrambleJson, "1234", "36")
 	assertScramble(t, ScrambleJson, "1234.5", "7581.450344")
 	assertScramble(t, ScrambleJson, "{\"foo\":1234}", "{\"foo\":1218}")
 	assertScramble(t, ScrambleJson, "{\"foo\":\"ハロー\",\"baz\":\"ワールド\"}", "{\"foo\":\"xYjlXNRqav\",\"baz\":\"PKwz5Yai7S\"}")

--- a/obfuscators.go
+++ b/obfuscators.go
@@ -260,7 +260,12 @@ func scrambleJsonData(dat interface{}, sumBytes []byte, sumLength int, index int
 				s[i] = '0' + (sumBytes[(i+index)%sumLength]+b)%10
 			}
 		}
-		return string(s), (index + len(s)) % sumLength
+		str := string(s)
+		str = strings.TrimLeft(str, "0")
+		if str == "" {
+			str = "0"
+		}
+		return str, (index + len(str)) % sumLength
 	case bool:
 		return fmt.Sprintf("%t", dat.(bool)), index
 	case nil:


### PR DESCRIPTION
JSON grammar rejects a numerical text which start with zero.

```
JSON.parse("6") // => OK
JSON.parse("06") // => NG
```